### PR TITLE
spsc-lite-js: propagate substitution in `drive`

### DIFF
--- a/spsc-lite-js/spsc.js
+++ b/spsc-lite-js/spsc.js
@@ -54,7 +54,16 @@ function base_supercompiler(program) {
 							var res = [];
 							for (var i = 0; i < inner_drs.length; i++) {
 								var inner_dr = inner_drs[i];
-								var gc = Lang.gcall(e.name, [inner_dr[0]].concat(e.args.slice(1)));
+								var gc = Lang.gcall(e.name, [inner_dr[0]].concat(e.args.slice(1)
+									.map(function (arg) {
+										if (inner_dr[1]) {
+											var map = {}
+											map[inner_dr[1][0].name] = Lang.constructor(inner_dr[1][1].name, inner_dr[1][1].args);
+											return sll_algebra.apply_subst(arg, map);
+										} else {
+											return arg;
+										}
+									})));
 								res.push([gc, inner_dr[1]]);
 							}
 							return res;

--- a/spsc-lite-js/test.js
+++ b/spsc-lite-js/test.js
@@ -26,6 +26,10 @@ const test_program = {
 		'gD(Z()) = Z();',
 		'gD(S(x)) = gD(S(S(x)));'
 	].join('\n'),
+	code2: [
+		'g1(C(x)) = B();',
+		'g2(B(), x) = x;'
+	].join('\n'),
 	fMain: Lang.frule(
 		'fMain',
 		[
@@ -485,6 +489,26 @@ var test_sc_4 = function () {
 	console.log('---');
 };
 
+// See <https://github.com/sergei-romanenko/spsc/issues/3>.
+var test_sc_5 = function () {
+	var pr = Parser.parse(test_program.code2).result;
+	var bsc = supercompiler(pr);
+	var exp = Parser.parse_exp('g2(g1(x), x)');
+
+	console.log('sc:');
+	console.log(exp.toString());
+	console.log(pr.toString());
+
+	var t = bsc.build_tree(exp);
+	var result = residuator(t).residuate();
+
+	console.log('sc result:');
+	console.log(result[0].toString());
+	console.log(result[1].toString());
+
+	console.log('---');
+};
+
 export const test_all = function () {
 	test_algebra_equals();
 	test_parser();
@@ -513,6 +537,7 @@ export const test_all = function () {
 	test_sc_2();
 	test_sc_3();
 	test_sc_4();
+	test_sc_5();
 };
 
 test_all();


### PR DESCRIPTION
See https://github.com/sergei-romanenko/spsc/issues/3.
